### PR TITLE
chore: support deletion_protection_enabled setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   Default is `true`.
 
+- [**`deletion_protection_enabled`**](#var-deletion_protection_enabled): *(Optional `bool`)*<a name="var-deletion_protection_enabled"></a>
+
+  Enables protection of an instance from accidental deletion protection across all surfaces (API, gcloud, Cloud Console and Terraform).
+
+  Default is `false`.
+
 - [**`activation_policy`**](#var-activation_policy): *(Optional `string`)*<a name="var-activation_policy"></a>
 
   This specifies when the instance should be active. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`.

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -162,6 +162,14 @@ section {
         END
       }
 
+      variable "deletion_protection_enabled" {
+        type        = bool
+        default     = false
+        description = <<-END
+          Enables protection of an instance from accidental deletion protection across all surfaces (API, gcloud, Cloud Console and Terraform).
+        END
+      }
+
       variable "activation_policy" {
         type        = string
         description = <<-END

--- a/main.tf
+++ b/main.tf
@@ -20,9 +20,10 @@ resource "google_sql_database_instance" "instance" {
   deletion_protection  = var.deletion_protection
 
   settings {
-    tier              = var.tier
-    activation_policy = var.activation_policy
-    availability_type = var.availability_type
+    tier                        = var.tier
+    activation_policy           = var.activation_policy
+    availability_type           = var.availability_type
+    deletion_protection_enabled = var.deletion_protection_enabled
 
     # disable disk_autoresize if the user requested a specific disk_size
     disk_autoresize       = var.disk_size != null ? false : var.disk_autoresize

--- a/test/unit-complete/main.tf
+++ b/test/unit-complete/main.tf
@@ -6,18 +6,19 @@ module "test" {
   tier             = "db-n1-standard-1"
 
   # add all optional arguments that create additional/extended resources
-  name                  = "unit-complete-main-${local.random_suffix}"
-  region                = var.gcp_region
-  master_instance_name  = "unit-complete-main-master-${local.random_suffix}"
-  project               = local.project_id
-  deletion_protection   = true
-  activation_policy     = "ALWAYS"
-  availability_type     = "REGIONAL"
-  disk_autoresize       = true
-  disk_autoresize_limit = 100
-  disk_size             = 10
-  disk_type             = "PD_SSD"
-  pricing_plan          = "PER_USE"
+  name                        = "unit-complete-main-${local.random_suffix}"
+  region                      = var.gcp_region
+  master_instance_name        = "unit-complete-main-master-${local.random_suffix}"
+  project                     = local.project_id
+  deletion_protection         = true
+  deletion_protection_enabled = false
+  activation_policy           = "ALWAYS"
+  availability_type           = "REGIONAL"
+  disk_autoresize             = true
+  disk_autoresize_limit       = 100
+  disk_size                   = 10
+  disk_type                   = "PD_SSD"
+  pricing_plan                = "PER_USE"
 
   user_labels = {
     "key1" = "value1"

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "deletion_protection" {
   default     = true
 }
 
+variable "deletion_protection_enabled" {
+  description = "(Optional) Enables protection of an instance from accidental deletion protection across all surfaces (API, gcloud, Cloud Console and Terraform)."
+  type        = bool
+  default     = false
+}
+
 variable "activation_policy" {
   description = "(Optional) This specifies when the instance should be active. Can be either ALWAYS, NEVER or ON_DEMAND."
   type        = string


### PR DESCRIPTION
GCP introduced the instance deletion protection in August 2022. The Terraform GCP provider has been upgraded recently to support that setting as well. This PR is to have `deletion_protection_enabled` flag to enable protection of an instance from accidental deletion protection across all surfaces (API, gcloud, Cloud Console and Terraform)
